### PR TITLE
Added Death Link

### DIFF
--- a/CelesteArchipelagoModule.cs
+++ b/CelesteArchipelagoModule.cs
@@ -18,10 +18,10 @@ namespace Celeste.Mod.CelesteArchipelago {
             Instance = this;
 #if DEBUG
             // debug builds use verbose logging
-            Logger.SetLogLevel(nameof(CelesteArchipelagoModule), LogLevel.Verbose);
+            Logger.SetLogLevel("CelesteArchipelago", LogLevel.Verbose);
 #else
             // release builds use info logging to reduce spam in log files
-            Logger.SetLogLevel(nameof(CelesteArchipelagoModule), LogLevel.Info);
+            Logger.SetLogLevel("CelesteArchipelago", LogLevel.Info);
 #endif
         }
 

--- a/CelesteArchipelagoModuleSettings.cs
+++ b/CelesteArchipelagoModuleSettings.cs
@@ -11,6 +11,26 @@ namespace Celeste.Mod.CelesteArchipelago {
         [SettingMaxLength(30)]
         public string Server { get; set; } = "archipelago.gg";
         public string Port { get; set; } = "38281";
+        public bool DeathLink
+        {
+            get => _deathLink;
+            set
+            {
+                
+                if (ArchipelagoController.Instance is not null &&
+                    ArchipelagoController.Instance.DeathLinkService is not null)
+                {
+                    if (_deathLink) {
+                        ArchipelagoController.Instance.DeathLinkService.EnableDeathLink();
+                    }
+                    else {
+                        ArchipelagoController.Instance.DeathLinkService.DisableDeathLink();
+                    }
+                }
+                _deathLink = value;
+            }
+        }
+        private bool _deathLink = false;
         private bool _Chat = false;
         public bool Chat { 
             get => _Chat; 

--- a/CelesteArchipelagoModuleSettings.cs
+++ b/CelesteArchipelagoModuleSettings.cs
@@ -11,16 +11,16 @@ namespace Celeste.Mod.CelesteArchipelago {
         [SettingMaxLength(30)]
         public string Server { get; set; } = "archipelago.gg";
         public string Port { get; set; } = "38281";
+        [SettingInGame(true)]
         public bool DeathLink
         {
             get => _deathLink;
             set
             {
                 
-                if (ArchipelagoController.Instance is not null &&
-                    ArchipelagoController.Instance.DeathLinkService is not null)
+                if (ArchipelagoController.Instance.DeathLinkService is not null)
                 {
-                    if (_deathLink) {
+                    if (!_deathLink) {
                         ArchipelagoController.Instance.DeathLinkService.EnableDeathLink();
                     }
                     else {

--- a/Networking/ArchipelagoController.cs
+++ b/Networking/ArchipelagoController.cs
@@ -278,6 +278,7 @@ namespace Celeste.Mod.CelesteArchipelago
 
             if (DeathLinkStatus == DeathLinkStatus.None && DeathAmnestyCount >= Instance.SlotData.DeathAmnestyMax - 1)
             {
+                ChatHandler.HandleMessage("Death Sent", Color.PaleVioletRed);
                 var deathLink = new DeathLink(Session.Players.GetPlayerAlias(Session.ConnectionInfo.Slot), "Celeste");
                 DeathLinkService.SendDeathLink(deathLink);
 

--- a/Networking/ArchipelagoController.cs
+++ b/Networking/ArchipelagoController.cs
@@ -68,7 +68,7 @@ namespace Celeste.Mod.CelesteArchipelago
         public DeathLinkService DeathLinkService { get; private set; }
         public DeathLinkStatus DeathLinkStatus { get; set; } = DeathLinkStatus.None;
         public bool isLocalDeath = true;
-        private long DeathAmnesityCount = 0;
+        private long DeathAmnestyCount = 0;
         private ChatHandler ChatHandler { get; set; }
         private Connection Connection { get; set; }
         private VictoryConditionOptions VictoryCondition
@@ -181,6 +181,7 @@ namespace Celeste.Mod.CelesteArchipelago
                         Session.MessageLog.OnMessageReceived -= HandleMessage;
                         Session.Items.ItemReceived -= ReceiveItemCallback;
                         ProgressionSystem = new NullProgression();
+                        DeathLinkService = null;
                     };
                 }
                 else
@@ -275,16 +276,16 @@ namespace Celeste.Mod.CelesteArchipelago
                 return;
             }
 
-            if (DeathLinkStatus == DeathLinkStatus.None && DeathAmnesityCount >= Instance.SlotData.DeathAmnestyMax - 1)
+            if (DeathLinkStatus == DeathLinkStatus.None && DeathAmnestyCount >= Instance.SlotData.DeathAmnestyMax - 1)
             {
                 var deathLink = new DeathLink(Session.Players.GetPlayerAlias(Session.ConnectionInfo.Slot), "Celeste");
                 DeathLinkService.SendDeathLink(deathLink);
 
-                DeathAmnesityCount = 0;
+                DeathAmnestyCount = 0;
             }
             else if (isLocalDeath)
             {
-                DeathAmnesityCount++;
+                DeathAmnestyCount++;
             }
         }
 

--- a/Networking/ArchipelagoController.cs
+++ b/Networking/ArchipelagoController.cs
@@ -162,7 +162,7 @@ namespace Celeste.Mod.CelesteArchipelago
                     Session.DataStorage[Scope.Slot, "CelestePlayState"].Initialize("1;0;0;dotutorial");
                     Session.DataStorage[Scope.Slot, "CelesteCheckpointState"].Initialize(long.MinValue);
 
-                    //CelesteArchipelagoModule.Settings.DeathLink = Instance.SlotData.DeathLink; // Bug: Cannot get DeathLink Data from user
+                    CelesteArchipelagoModule.Settings.DeathLink = SlotData.DeathLink == 1;
                     DeathLinkService = Session.CreateDeathLinkService();
                     DeathLinkService.OnDeathLinkReceived += ReceiveDeathLinkCallback;
                     
@@ -279,7 +279,7 @@ namespace Celeste.Mod.CelesteArchipelago
             if (DeathLinkStatus == DeathLinkStatus.None && DeathAmnestyCount >= Instance.SlotData.DeathAmnestyMax - 1)
             {
                 ChatHandler.HandleMessage("Death Sent", Color.PaleVioletRed);
-                var deathLink = new DeathLink(Session.Players.GetPlayerAlias(Session.ConnectionInfo.Slot), "Celeste");
+                DeathLink deathLink = new DeathLink(Session.Players.GetPlayerAlias(Session.ConnectionInfo.Slot), "Celeste");
                 DeathLinkService.SendDeathLink(deathLink);
 
                 DeathAmnestyCount = 0;

--- a/Networking/ArchipelagoSlotData.cs
+++ b/Networking/ArchipelagoSlotData.cs
@@ -16,6 +16,8 @@ namespace Celeste.Mod.CelesteArchipelago
         public long VictoryCondition { get; set; } = 0;
         public long ProgressionSystem { get; set; } = 0;
         public long DisableHeartGates { get; set; } = 0;
+        public bool DeathLink { get; set; } = false;
+        public long DeathAmnestyMax { get; set; } = 20;
 
         private Dictionary<string, PropertyInfo> keyPropertyMap = new Dictionary<string, PropertyInfo>
         {
@@ -27,6 +29,8 @@ namespace Celeste.Mod.CelesteArchipelago
             { "progression_system", typeof(ArchipelagoSlotData).GetProperty("ProgressionSystem") },
             { "goal_level", typeof(ArchipelagoSlotData).GetProperty("VictoryCondition") },
             { "disable_heart_gates", typeof(ArchipelagoSlotData).GetProperty("DisableHeartGates") },
+            { "death_link", typeof(ArchipelagoSlotData).GetProperty("DeathLink") },
+            { "death_link_amnesty", typeof(ArchipelagoSlotData).GetProperty("DeathAmnestyMax") },
         };
 
         public ArchipelagoSlotData(Dictionary<string, object> slotData)

--- a/Networking/ArchipelagoSlotData.cs
+++ b/Networking/ArchipelagoSlotData.cs
@@ -16,7 +16,7 @@ namespace Celeste.Mod.CelesteArchipelago
         public long VictoryCondition { get; set; } = 0;
         public long ProgressionSystem { get; set; } = 0;
         public long DisableHeartGates { get; set; } = 0;
-        public bool DeathLink { get; set; } = false;
+        public long DeathLink { get; set; } = 0;
         public long DeathAmnestyMax { get; set; } = 20;
 
         private Dictionary<string, PropertyInfo> keyPropertyMap = new Dictionary<string, PropertyInfo>

--- a/Networking/DeathLinkStatus.cs
+++ b/Networking/DeathLinkStatus.cs
@@ -1,0 +1,11 @@
+namespace Celeste.Mod.CelesteArchipelago;
+
+public enum DeathLinkStatus
+{
+    // no deathlink has been received since the last time madeline completed dying from deathlink
+    None = 0,
+    // a deathlink has been received but madeline has not started dying yet
+    Pending = 1,
+    // a deathlink has been received and executed but madeline has not respawned yet
+    Dying = 2
+}

--- a/PatchedObjects/PatchedLevel.cs
+++ b/PatchedObjects/PatchedLevel.cs
@@ -6,14 +6,23 @@ namespace Celeste.Mod.CelesteArchipelago
     {
         public void Load()
         {
+            Everest.Events.Level.OnEnter += OnEnter;
             Everest.Events.Level.OnTransitionTo += OnTransitionTo;
             Everest.Events.Level.OnExit += OnExit;
         }
 
         public void Unload()
         {
+            Everest.Events.Level.OnEnter -= OnEnter;
             Everest.Events.Level.OnTransitionTo -= OnTransitionTo;
             Everest.Events.Level.OnExit -= OnExit;
+        }
+
+        private static void OnEnter(Session session, bool fromSaveData)
+        {
+            var state = new PlayState(true, session.Area, session.LevelData.Name);
+            Logger.Log("CelesteArchipelago", $"Entering level. Setting PlayState to {state}");
+            ArchipelagoController.Instance.PlayState = state;
         }
 
         private static void OnTransitionTo(Level level, LevelData next, Vector2 direction)

--- a/PatchedObjects/PatchedPlayer.cs
+++ b/PatchedObjects/PatchedPlayer.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.CelesteArchipelago;
+
+public class PatchedPlayer : IPatchable
+{
+    public void Load()
+    {
+        On.Celeste.Player.Update += Update;
+        Everest.Events.Player.OnSpawn += OnSpawn;
+        Everest.Events.Player.OnDie += OnDie;
+    }
+
+    public void Unload()
+    {
+        On.Celeste.Player.Update -= Update;
+        Everest.Events.Player.OnSpawn -= OnSpawn;
+        Everest.Events.Player.OnDie -= OnDie;
+    }
+
+    private static void Update(On.Celeste.Player.orig_Update orig, Player self)
+    {
+        if (ArchipelagoController.Instance.DeathLinkStatus == DeathLinkStatus.Pending)
+        {
+            self.Die(Vector2.Zero, true);
+        }
+        orig.Invoke(self);
+    }
+
+    private static void OnSpawn(Player player)
+    {
+        if (ArchipelagoController.Instance.DeathLinkStatus == DeathLinkStatus.Dying)
+        {
+            ArchipelagoController.Instance.DeathLinkStatus = DeathLinkStatus.None;
+        }
+    }
+
+    private static void OnDie(Player player)
+    {
+        ArchipelagoController.Instance.SendDeathLinkCallback();
+        ArchipelagoController.Instance.DeathLinkStatus = DeathLinkStatus.Dying;
+        ArchipelagoController.Instance.isLocalDeath = true;
+    }
+}

--- a/Progression/DefaultProgression.cs
+++ b/Progression/DefaultProgression.cs
@@ -141,7 +141,6 @@ namespace Celeste.Mod.CelesteArchipelago
 
         public int GetTotalVisually(CollectableType collectable)
         {
-            
             switch (collectable)
             {
                 case CollectableType.CASSETTE:

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
-- Name: CelesteArchipelagoDev
-  Version: 0.3.1
+- Name: CelesteArchipelago
+  Version: 0.3.2
   DLL: bin/CelesteArchipelago.dll
   Dependencies:
     - Name: Everest


### PR DESCRIPTION
- Added death link within the game, borrowing code from MageoMage. Allows to switch death_link from ingame.
- Added death amnesty.

2 Known Bugs
- Cannot read death_link value from Archipelago yaml
- After exiting an archipelago game and attempting to switch the death link freezes and crashes